### PR TITLE
Use shared non-linear target transform in judge-weight modifier (DRY)

### DIFF
--- a/core/common/utils.py
+++ b/core/common/utils.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import torch
+
+
+def sequence_scorer_target_transform(x: torch.Tensor) -> torch.Tensor:
+    """
+    Non-linear transform used for sequence scorer targets and judge-weight modifier.
+    Implements: y = 1 - (-x^4 + 2x^3 - 2x + 1)
+    Assumes x in [0, 1]; returns y in [0, 1].
+    """
+    y = 1 - (-x**4 + 2 * x**3 - 2 * x + 1)
+    return y
+

--- a/docs/loss_modifiers.md
+++ b/docs/loss_modifiers.md
@@ -354,14 +354,14 @@ weights = [
 
 ### Sequence Scoring Judge Weight Modifier
 
-Purpose: In LANGUAGE_MODEL mode, dynamically reweight each sequence’s loss using a separate SEQUENCE_SCORER “judge” model that outputs a per‑sample wrongness factor in [0,1] (lower is better). The modifier compares this wrongness to the masking ratio and scales loss by (wrongness / masking_ratio)^exponent with clamping.
+Purpose: In LANGUAGE_MODEL mode, dynamically reweight each sequence’s loss using a separate SEQUENCE_SCORER “judge” model that outputs a per‑sample wrongness factor in [0,1] (lower is better). The modifier compares this wrongness to the transformed masking ratio y (y = 1 - (-x^4 + 2x^3 - 2x + 1)) and scales loss by (wrongness / y)^exponent with clamping.
 
 How it works:
 1) Sampling: From current LM logits (B, T, V), sample one token per position (single pass). No iterative decoding.
 2) Judge input: If the judge config contains a CLS token id, prepend it; crop to the judge’s block_size.
 3) Scoring: Run the judge in eval+no_grad to obtain wrongness per sample (shape (B,), values in [0,1]).
-4) Masking ratio: Compute per sample from targets (or provided mask): mask = (targets != ignore_index); ratio = sum(mask_i)/T.
-5) Factor per sample: factor_i = clamp((wrong_i / clamp(ratio_i, eps))^exponent, min_factor, max_factor).
+4) Masking ratio (x): Compute per sample from targets (or provided mask): mask = (targets != ignore_index); x = sum(mask_i)/T. Apply shared transform y = 1 - (-x^4 + 2x^3 - 2x + 1).
+5) Factor per sample: factor_i = clamp((wrong_i / clamp(y_i, eps))^exponent, min_factor, max_factor).
 6) Loss application:
    - If a per_position_loss tensor is present (e.g., produced by Target Smoothing), multiply it by factor_i per sample and let the pipeline aggregate.
    - Otherwise, multiply the scalar loss by mean(factor).


### PR DESCRIPTION
This PR introduces a minimal DRY change:

- Adds core/common/utils.py with sequence_scorer_target_transform(x) implementing y = 1 - (-x^4 + 2x^3 - 2x + 1)
- Updates data/sequence_scorer/prepare_streaming.py to import and use the shared transform (removes local _transform_ratio_to_target)
- Updates loss_modifiers/sequence_judge_weight_modifier.py to apply the same shared transform to its masking ratio before computing the judge-weight factor; clamps to [eps, 1]
- Updates docs/loss_modifiers.md to document the use of the transformed ratio y in the modifier

No other refactors; behavior change is limited to using the shared transform in the modifier as requested.

Branch: feature/judge-weight-dry-transform
Base: training_experiments

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author