### PR TITLE
Schedule judge_weight_exponent via judge_start_iter/judge_max_iter

### DIFF
--- a/core/trainer.py
+++ b/core/trainer.py
@@ -116,6 +116,11 @@ class Trainer:
             self.training_step.maybe_unfreeze(self.iter_num)
 
             # forward/backward/update handled by TrainingStep
+            # Expose current iteration to loss modifiers
+            try:
+                self.evaluator.loss_modifier_pipeline.current_iter = self.iter_num
+            except Exception:
+                pass
             loss, batch = self.training_step.execute_step(
                 batch, self.evaluator.loss_modifier_pipeline, self.consumer, self.device
             )

--- a/loss_modifiers/__init__.py
+++ b/loss_modifiers/__init__.py
@@ -120,6 +120,8 @@ def create_loss_modifier_pipeline(config):
             'enabled': True,
             'judge_weight_checkpoint': get_config_value('judge_weight_checkpoint', None),
             'judge_weight_exponent': get_config_value('judge_weight_exponent', 1.0),
+            'judge_start_iter': get_config_value('judge_start_iter', None),
+            'judge_max_iter': get_config_value('judge_max_iter', None),
             'judge_weight_min_factor': get_config_value('judge_weight_min_factor', 0.1),
             'judge_weight_max_factor': get_config_value('judge_weight_max_factor', 10.0),
             'judge_weight_eps': get_config_value('judge_weight_eps', 1e-6),

--- a/loss_modifiers/pipeline.py
+++ b/loss_modifiers/pipeline.py
@@ -24,15 +24,16 @@ class LossModifierPipeline:
     def __init__(self, modifiers: Optional[List[BaseLossModifier]] = None):
         """
         Initialize the pipeline with optional list of modifiers.
-        
+
         Args:
             modifiers: List of loss modifiers to include in the pipeline
         """
         self.modifiers = modifiers or []
         self._enabled_modifiers = []
         self._temporarily_disabled = False
+        self.current_iter: int = 0
         self._update_enabled_modifiers()
-    
+
     def add_modifier(self, modifier: BaseLossModifier) -> None:
         """
         Add a new modifier to the pipeline.
@@ -87,6 +88,9 @@ class LossModifierPipeline:
         # Whether any modifier in this pipeline produced/replaced per_position_loss
         per_position_loss_owned = False
         extra_kwargs = dict(kwargs)
+        # Always pass current iteration to modifiers if available
+        if 'iter_num' not in extra_kwargs:
+            extra_kwargs['iter_num'] = self.current_iter
 
         modified_loss = loss
         for modifier in compatible_modifiers:

--- a/loss_modifiers/sequence_judge_weight_modifier.py
+++ b/loss_modifiers/sequence_judge_weight_modifier.py
@@ -44,6 +44,15 @@ class SequenceScoringJudgeWeightModifier(BaseLossModifier):
         self.min_factor: float = float(config.get('judge_weight_min_factor', 0.1))
         self.max_factor: float = float(config.get('judge_weight_max_factor', 10.0))
         self.eps: float = float(config.get('judge_weight_eps', 1e-6))
+        # Scheduling (required when enabled)
+        self.judge_start_iter = config.get('judge_start_iter', None)
+        self.judge_max_iter = config.get('judge_max_iter', None)
+        if self.judge_start_iter is None or self.judge_max_iter is None:
+            raise ValueError("judge_start_iter and judge_max_iter must be provided when judge_weight_modifier_enabled=True")
+        self.judge_start_iter = int(self.judge_start_iter)
+        self.judge_max_iter = int(self.judge_max_iter)
+        if self.judge_max_iter < self.judge_start_iter:
+            raise ValueError(f"judge_max_iter ({self.judge_max_iter}) must be >= judge_start_iter ({self.judge_start_iter})")
 
         # Device/dtype from main training config
         self.device: str = str(config.get('device', 'cuda' if torch.cuda.is_available() else 'cpu'))
@@ -185,8 +194,18 @@ class SequenceScoringJudgeWeightModifier(BaseLossModifier):
         y = sequence_scorer_target_transform(ratio)
         y = torch.clamp(y, min=self.eps, max=1.0)
         factor = wrong / y
+        # Compute scheduled exponent based on current iteration
+        iter_num = int(kwargs.get('iter_num', 0) or 0)
+        if iter_num <= self.judge_start_iter:
+            effective_exponent = 0.0
+        elif iter_num >= self.judge_max_iter:
+            effective_exponent = float(self.exponent)
+        else:
+            span = max(self.judge_max_iter - self.judge_start_iter, 1)
+            frac = float(iter_num - self.judge_start_iter) / float(span)
+            effective_exponent = float(self.exponent) * max(min(frac, 1.0), 0.0)
         # Per-sample factor
-        multiplier = torch.clamp((factor) ** self.exponent, min=self.min_factor, max=self.max_factor)
+        multiplier = torch.clamp((factor) ** effective_exponent, min=self.min_factor, max=self.max_factor)
 
         # Metrics: only multiplayer_median and multiplayer_std_ema (EMA factor 0.99)
         with torch.no_grad():


### PR DESCRIPTION
Implements a minimal, explicit schedule for the judge-weight modifier exponent:

- Read judge_start_iter and judge_max_iter from config (train_char_diffusion_judge_weight.py)
- Pass these to SequenceScoringJudgeWeightModifier via loss_modifiers/__init__.py
- Propagate current iteration to modifiers: LossModifierPipeline now passes iter_num; Trainer sets pipeline.current_iter each loop
- In SequenceScoringJudgeWeightModifier, compute an effective exponent per iteration:
  - 0 for iter <= judge_start_iter
  - Linear ramp to judge_weight_exponent between judge_start_iter and judge_max_iter
  - Stays at judge_weight_exponent afterwards
- Fail fast if scheduling params are missing when the modifier is enabled

No changes to train.py; minimal and localized edits.

Branch: feature/judge-exponent-schedule
Base: training_experiments

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author