### PR TITLE
Add PAD token handling and drop GPT-2 fallback

### DIFF
--- a/config/finetune_shakespeare.py
+++ b/config/finetune_shakespeare.py
@@ -8,7 +8,7 @@ wandb_project = 'shakespeare'
 wandb_run_name = 'ft-' + str(time.time())
 
 dataset = 'shakespeare'
-init_from = 'gpt2-xl' # this is the largest GPT-2 model
+init_from = 'resume'  # fine-tune from an existing repository checkpoint
 
 # only save checkpoints if the validation loss improves
 always_save_checkpoint = False

--- a/data/char_diffusion/masking_utils.py
+++ b/data/char_diffusion/masking_utils.py
@@ -51,7 +51,8 @@ def apply_bert_style_corruption_cpu(
     # Apply random tokens
     if random_positions.any():
         num_random = random_positions.sum().item()
-        candidates = _candidate_tensor(random_token_ids, mask.device)
+        target_device = x.device if isinstance(x, torch.Tensor) else mask.device
+        candidates = _candidate_tensor(random_token_ids, target_device)
         if candidates.numel() == 0:
             raise ValueError("random_token_ids must contain at least one token")
         indices = torch.randint(

--- a/data/char_diffusion/masking_utils.py
+++ b/data/char_diffusion/masking_utils.py
@@ -7,8 +7,20 @@ import math
 from typing import Dict, Any
 
 
-def apply_bert_style_corruption_cpu(x: torch.Tensor, mask: torch.Tensor, 
-                                  mask_token_id: int, vocab_size: int, rng) -> torch.Tensor:
+def _candidate_tensor(random_token_ids, device: torch.device) -> torch.Tensor:
+    """Materialize the candidate token tensor on the requested device."""
+    if isinstance(random_token_ids, torch.Tensor):
+        return random_token_ids.to(device)
+    return torch.tensor(list(random_token_ids), dtype=torch.long, device=device)
+
+
+def apply_bert_style_corruption_cpu(
+    x: torch.Tensor,
+    mask: torch.Tensor,
+    mask_token_id: int,
+    random_token_ids,
+    rng,
+) -> torch.Tensor:
     """
     Optimized BERT-style corruption using tensor operations.
     Applies 80/10/10 rule: 80% [MASK], 10% random token, 10% unchanged.
@@ -17,7 +29,7 @@ def apply_bert_style_corruption_cpu(x: torch.Tensor, mask: torch.Tensor,
         x: Original input tokens (batch_size, seq_len)
         mask: Boolean mask of positions to corrupt (batch_size, seq_len)
         mask_token_id: The ID of the [MASK] token
-        vocab_size: Size of vocabulary for random token generation
+        random_token_ids: Iterable of token IDs eligible for random replacement
         rng: Torch random number generator for consistent randomization
         
     Returns:
@@ -39,16 +51,25 @@ def apply_bert_style_corruption_cpu(x: torch.Tensor, mask: torch.Tensor,
     # Apply random tokens
     if random_positions.any():
         num_random = random_positions.sum().item()
-        random_tokens = torch.randint(
-            0, vocab_size, (num_random,), generator=rng, device=mask.device
+        candidates = _candidate_tensor(random_token_ids, mask.device)
+        if candidates.numel() == 0:
+            raise ValueError("random_token_ids must contain at least one token")
+        indices = torch.randint(
+            0, candidates.numel(), (num_random,), generator=rng, device=mask.device
         )
+        random_tokens = candidates.index_select(0, indices)
         corrupted_x[random_positions] = random_tokens
     
     return corrupted_x
 
 
-def apply_random_masking_cpu(x: torch.Tensor, mask_probability: float, 
-                           mask_token_id: int, vocab_size: int, rng=None) -> tuple[torch.Tensor, torch.Tensor]:
+def apply_random_masking_cpu(
+    x: torch.Tensor,
+    mask_probability: float,
+    mask_token_id: int,
+    random_token_ids,
+    rng=None,
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Optimized random masking for BERT-style training using tensor operations.
     
@@ -56,7 +77,7 @@ def apply_random_masking_cpu(x: torch.Tensor, mask_probability: float,
         x: Input tokens (batch_size, seq_len)
         mask_probability: Probability of masking each token (0.0 to 1.0)
         mask_token_id: Token ID for [MASK] token
-        vocab_size: Size of vocabulary for random token generation
+        random_token_ids: Iterable of token IDs eligible for random replacement
         rng: Random number generator
         
     Returns:
@@ -68,14 +89,22 @@ def apply_random_masking_cpu(x: torch.Tensor, mask_probability: float,
     mask = mask_tensor < mask_probability
     
     # Apply BERT-style corruption
-    corrupted_x = apply_bert_style_corruption_cpu(x, mask, mask_token_id, vocab_size, rng)
+    corrupted_x = apply_bert_style_corruption_cpu(
+        x, mask, mask_token_id, random_token_ids, rng
+    )
     
     return corrupted_x, mask
 
 
-def apply_target_driven_sticky_masking_cpu(x: torch.Tensor, target_masked_ratio: float, 
-                                         p1_probability: float, p2_probability: float, 
-                                         mask_token_id: int, vocab_size: int, rng) -> tuple[torch.Tensor, torch.Tensor]:
+def apply_target_driven_sticky_masking_cpu(
+    x: torch.Tensor,
+    target_masked_ratio: float,
+    p1_probability: float,
+    p2_probability: float,
+    mask_token_id: int,
+    random_token_ids,
+    rng,
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     CPU-optimized target-driven sticky masking for unmasking training.
     
@@ -85,7 +114,7 @@ def apply_target_driven_sticky_masking_cpu(x: torch.Tensor, target_masked_ratio:
         p1_probability: Probability of masking when no neighbors are masked
         p2_probability: Probability of masking when neighbors are masked
         mask_token_id: Token ID to use for masking
-        vocab_size: Size of vocabulary for random token generation
+        random_token_ids: Iterable of token IDs eligible for random replacement
         rng: Random number generator
         
     Returns:
@@ -173,13 +202,16 @@ def apply_target_driven_sticky_masking_cpu(x: torch.Tensor, target_masked_ratio:
             current_mask.index_copy_(0, remaining_idx, sub_mask)
             current_counts[remaining_idx] += remaining_sub
 
-    corrupted_x = apply_bert_style_corruption_cpu(x, current_mask, mask_token_id, vocab_size, rng)
+    corrupted_x = apply_bert_style_corruption_cpu(
+        x, current_mask, mask_token_id, random_token_ids, rng
+    )
 
     return corrupted_x, current_mask
 
 
-def apply_span_masking_cpu(x: torch.Tensor, spans_count: int, 
-                         mask_token_id: int, vocab_size: int, rng) -> tuple[torch.Tensor, torch.Tensor]:
+def apply_span_masking_cpu(
+    x: torch.Tensor, spans_count: int, mask_token_id: int, rng
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     CPU-optimized span masking for unmasking training.
     Masks spans_count continuous areas in the input.
@@ -188,7 +220,6 @@ def apply_span_masking_cpu(x: torch.Tensor, spans_count: int,
         x: Input tokens (batch_size, seq_len)
         spans_count: Number of continuous spans to mask
         mask_token_id: Token ID to use for masking
-        vocab_size: Size of original vocabulary (not used for span masking)
         rng: Random number generator
         
     Returns:
@@ -239,8 +270,13 @@ def apply_span_masking_cpu(x: torch.Tensor, spans_count: int,
     return masked_x, mask
 
 
-def apply_stage_masking(x: torch.Tensor, stage_config: Dict[str, Any], 
-                       mask_token_id: int, vocab_size: int, rng) -> tuple[torch.Tensor, torch.Tensor]:
+def apply_stage_masking(
+    x: torch.Tensor,
+    stage_config: Dict[str, Any],
+    mask_token_id: int,
+    random_token_ids,
+    rng,
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Apply masking based on stage configuration type.
     
@@ -248,7 +284,7 @@ def apply_stage_masking(x: torch.Tensor, stage_config: Dict[str, Any],
         x: Input tokens (batch_size, seq_len)
         stage_config: Stage configuration dictionary
         mask_token_id: Token ID to use for masking
-        vocab_size: Size of original vocabulary (for random token generation, excluding special tokens)
+        random_token_ids: Iterable of token IDs eligible for random replacement
         rng: Random number generator
         
     Returns:
@@ -265,7 +301,9 @@ def apply_stage_masking(x: torch.Tensor, stage_config: Dict[str, Any],
         thresholds = mask_ratios.unsqueeze(1)
         rand_vals = torch.rand((batch_size, seq_len), generator=rng, dtype=torch.float, device=x.device)
         mask = rand_vals < thresholds
-        corrupted_x = apply_bert_style_corruption_cpu(x, mask, mask_token_id, vocab_size, rng)
+        corrupted_x = apply_bert_style_corruption_cpu(
+            x, mask, mask_token_id, random_token_ids, rng
+        )
         return corrupted_x, mask
         
     elif stage_type == 'sticky':
@@ -274,13 +312,18 @@ def apply_stage_masking(x: torch.Tensor, stage_config: Dict[str, Any],
         p2_probability = stage_config['p2_probability']
         
         return apply_target_driven_sticky_masking_cpu(
-            x, target_masked_ratio, p1_probability, p2_probability, 
-            mask_token_id, vocab_size, rng
+            x,
+            target_masked_ratio,
+            p1_probability,
+            p2_probability,
+            mask_token_id,
+            random_token_ids,
+            rng,
         )
         
     elif stage_type == 'span':
         spans_count = stage_config['spans_count']
-        return apply_span_masking_cpu(x, spans_count, mask_token_id, vocab_size, rng)
+        return apply_span_masking_cpu(x, spans_count, mask_token_id, rng)
         
     else:
         raise ValueError(f"Unknown stage type: {stage_type}")

--- a/model.py
+++ b/model.py
@@ -170,7 +170,7 @@ class Block(nn.Module):
 @dataclass
 class GPTConfig:
     block_size: int = 1024
-    vocab_size: int = 50304 # GPT-2 vocab_size of 50257, padded up to nearest multiple of 64 for efficiency
+    vocab_size: int = 0  # must be provided by the dataset metadata or checkpoint
     n_layer: int = 12
     n_head: int = 12
     n_embd: int = 768

--- a/model_setup.py
+++ b/model_setup.py
@@ -33,12 +33,15 @@ class ModelSetup:
         self.start = start
 
         model, checkpoint = self._load_model()
-        encode, decode, space_token_id = self._load_tokenizer(checkpoint)
+        encode, decode, space_token_id, pad_token_id = self._load_tokenizer(checkpoint)
 
         self.model = model
         self.encode = encode
         self.decode = decode
         self.space_token_id = space_token_id
+        self.pad_token_id = pad_token_id
+        if getattr(self.model.config, "pad_token_id", pad_token_id) != pad_token_id:
+            self.model.config.pad_token_id = pad_token_id
         self.prompt = self._build_prompt(start_text=self._resolve_start_text())
         self.initial_length = self.prompt.size(0)
         self.block_size = self.model.config.block_size
@@ -85,7 +88,12 @@ class ModelSetup:
 
     def _load_tokenizer(
         self, checkpoint: Optional[dict]
-    ) -> Tuple[Callable[[str], Sequence[int]], Callable[[Sequence[int]], str], int]:
+    ) -> Tuple[
+        Callable[[str], Sequence[int]],
+        Callable[[Sequence[int]], str],
+        int,
+        int,
+    ]:
         load_meta = False
         meta_path: Optional[str] = None
         if (
@@ -102,6 +110,12 @@ class ModelSetup:
                 meta = pickle.load(f)
             stoi = meta["stoi"]
             itos = meta["itos"]
+            pad_value = meta.get("pad_token_id")
+            pad_token_id = int(pad_value) if pad_value is not None else None
+            if pad_token_id is None:
+                raise ValueError(
+                    "pad_token_id missing from dataset metadata; tokenizer cannot represent padding."
+                )
             if " " not in stoi:
                 raise ValueError(
                     "Space character not found in dataset vocabulary; cannot perform space-based re-noising."
@@ -128,8 +142,10 @@ class ModelSetup:
                         encode_unknown_cache.update(unseen)
                 return ids
 
-            decode = lambda token_ids: "".join(itos[i] for i in token_ids)
-            return encode, decode, space_token_id
+            def decode(token_ids: Sequence[int]) -> str:
+                return "".join(itos[i] for i in token_ids if i != pad_token_id)
+
+            return encode, decode, space_token_id, pad_token_id
 
         raise FileNotFoundError(
             "Dataset metadata (meta.pkl) not found; GPT-2 tokenizer fallback has been removed."

--- a/sample.py
+++ b/sample.py
@@ -19,7 +19,7 @@ from sampling_utils import (
 )
 
 # -----------------------------------------------------------------------------
-init_from = 'resume' # either 'resume' (from an out_dir) or a gpt2 variant (e.g. 'gpt2-xl')
+init_from = 'resume' # sampling now requires a checkpoint produced by this repository
 out_dir = 'out-char-random-replacement' # ignored if init_from is not 'resume'
 ckpt_name = 'new_hope_4_9000.pt'
 start = "POMPEY:\n" # or "<|endoftext|>" or etc. Can also specify a file, use as: "FILE:prompt.txt"

--- a/sample.py
+++ b/sample.py
@@ -85,6 +85,7 @@ setup = ModelSetup(
 model = setup.model
 decode = setup.decode
 space_token_id = setup.space_token_id
+pad_token_id = setup.pad_token_id
 prompt = setup.prompt
 initial_length = setup.initial_length
 block_size = setup.block_size
@@ -97,7 +98,12 @@ with torch.no_grad():
             seq_length = block_size
             max_token_pos = min(seq_length, initial_length + max_new_tokens)
 
-            x = torch.zeros((1, seq_length), dtype=torch.long, device=device)
+            x = torch.full(
+                (1, seq_length),
+                fill_value=pad_token_id,
+                dtype=torch.long,
+                device=device,
+            )
             x[0, :initial_length] = prompt
 
             if temperature <= 0:
@@ -110,6 +116,7 @@ with torch.no_grad():
             last_delete_indices: List[int] = []
 
             logits, _ = model(x)
+            logits[..., pad_token_id] = torch.finfo(logits.dtype).min
             last_log_probs = torch.log_softmax(logits, dim=-1).detach()
             display = DiffusionDisplay(decode)
 
@@ -189,7 +196,7 @@ with torch.no_grad():
                         del_indices,
                         max_token_pos=max_token_pos,
                         initial_length=initial_length,
-                        fill_id=space_token_id,
+                        fill_id=pad_token_id,
                         prior_insertions=applied_insertions,
                     )
                 else:
@@ -215,6 +222,7 @@ with torch.no_grad():
                 )
                 logits, _ = model(x)
                 logits = logits / temperature
+                logits[..., pad_token_id] = torch.finfo(logits.dtype).min
 
                 # Convert logits to log-probabilities for every token position, then exponentiate
                 # to obtain probabilities for sampling.
@@ -251,7 +259,7 @@ with torch.no_grad():
                 # Zero out any positions beyond the active window so that the next iteration continues to
                 # treat them as padding (i.e., not part of the diffusion process yet).
                 if max_token_pos < seq_length:
-                    x[:, max_token_pos:] = 0
+                    x[:, max_token_pos:] = pad_token_id
 
                 tokens_for_display = x[0, :max_token_pos].tolist()
                 display.emit_iteration(


### PR DESCRIPTION
## Summary
- add a [PAD] token to the character vocabulary and surface its metadata for downstream consumers
- exclude special tokens from corruption by updating masking utilities and newline-aligned random-replacement batches
- remove GPT-2 initialization/tokenizer fallbacks and require repository checkpoints for sampling and configs

## Testing
- python -m py_compile data/char_diffusion/masking_utils.py data/char_diffusion/prepare_streaming.py data/char_random_replacement/prepare_streaming.py model_setup.py sample.py config/finetune_shakespeare.py model.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69107b8cdb648324be9c486a8b89b462)